### PR TITLE
META: тестовое использование OneOf вместо Results в сервисах

### DIFF
--- a/backend/Onied/Courses/Courses.csproj
+++ b/backend/Onied/Courses/Courses.csproj
@@ -18,6 +18,7 @@
         </PackageReference>
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2"/>
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL.Design" Version="1.1.0"/>
+        <PackageReference Include="OneOf" Version="3.0.263"/>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
     </ItemGroup>
 

--- a/backend/Onied/Courses/Services/Abstractions/ICheckTaskManagementService.cs
+++ b/backend/Onied/Courses/Services/Abstractions/ICheckTaskManagementService.cs
@@ -1,18 +1,19 @@
 using Courses.Dtos;
 using Courses.Models;
 using Microsoft.AspNetCore.Http.HttpResults;
+using OneOf;
 using Task = System.Threading.Tasks.Task;
 
 namespace Courses.Services.Abstractions;
 
 public interface ICheckTaskManagementService
 {
-    public Task<Results<Ok<TasksBlock>, NotFound, ForbidHttpResult>> TryGetTaskBlock(
+    public Task<OneOf<Ok<TasksBlock>, NotFound, ForbidHttpResult>> TryGetTaskBlock(
         Guid userId, int courseId, int blockId,
         bool includeVariants = false,
         bool includeAnswers = false);
 
-    public Results<Ok<List<UserTaskPoints>>, NotFound<string>, BadRequest<string>> GetUserTaskPoints(
+    public OneOf<Ok<List<UserTaskPoints>>, NotFound<string>, BadRequest<string>> GetUserTaskPoints(
         List<UserInputDto> inputsDto,
         TasksBlock block,
         Guid userId);

--- a/backend/Onied/Courses/Services/Abstractions/ICourseManagementService.cs
+++ b/backend/Onied/Courses/Services/Abstractions/ICourseManagementService.cs
@@ -1,9 +1,10 @@
 ﻿using Courses.Models;
 using Microsoft.AspNetCore.Http.HttpResults;
+using OneOf;
 
 namespace Courses.Services.Abstractions;
 
 public interface ICourseManagementService
 {
-    public Task<Results<Ok<Course>, NotFound, ForbidHttpResult>> CheckCourseAuthorAsync(int courseId, string? userId);
+    public Task<OneOf<Ok<Course>, NotFound, ForbidHttpResult>> CheckCourseAuthorAsync(int courseId, string? userId);
 }

--- a/backend/Onied/Courses/Services/CheckTaskManagementService.cs
+++ b/backend/Onied/Courses/Services/CheckTaskManagementService.cs
@@ -2,6 +2,7 @@ using Courses.Dtos;
 using Courses.Models;
 using Courses.Services.Abstractions;
 using Microsoft.AspNetCore.Http.HttpResults;
+using OneOf;
 using Task = System.Threading.Tasks.Task;
 
 namespace Courses.Services;
@@ -13,7 +14,7 @@ public class CheckTaskManagementService(
     ICheckTasksService checkTasksService)
     : ICheckTaskManagementService
 {
-    public async Task<Results<Ok<TasksBlock>, NotFound, ForbidHttpResult>> TryGetTaskBlock(
+    public async Task<OneOf<Ok<TasksBlock>, NotFound, ForbidHttpResult>> TryGetTaskBlock(
         Guid userId, int courseId, int blockId,
         bool includeVariants = false,
         bool includeAnswers = false)
@@ -29,7 +30,7 @@ public class CheckTaskManagementService(
         return TypedResults.Ok(block);
     }
 
-    public Results<Ok<List<UserTaskPoints>>, NotFound<string>, BadRequest<string>> GetUserTaskPoints(
+    public OneOf<Ok<List<UserTaskPoints>>, NotFound<string>, BadRequest<string>> GetUserTaskPoints(
         List<UserInputDto> inputsDto,
         TasksBlock block,
         Guid userId)

--- a/backend/Onied/Courses/Services/CourseManagementService.cs
+++ b/backend/Onied/Courses/Services/CourseManagementService.cs
@@ -1,12 +1,14 @@
 ﻿using Courses.Models;
 using Courses.Services.Abstractions;
 using Microsoft.AspNetCore.Http.HttpResults;
+using OneOf;
 
 namespace Courses.Services;
 
 public class CourseManagementService(ICourseRepository courseRepository) : ICourseManagementService
 {
-    public async Task<Results<Ok<Course>, NotFound, ForbidHttpResult>> CheckCourseAuthorAsync(int courseId, string? userId)
+    public async Task<OneOf<Ok<Course>, NotFound, ForbidHttpResult>> CheckCourseAuthorAsync(int courseId,
+        string? userId)
     {
         var course = await courseRepository.GetCourseAsync(courseId);
         if (course == null)


### PR DESCRIPTION
Проблема Results -- в том, как мы его используем (dynamic). Используя стороннюю библиотеку OneOf можно избежать применения динамической диспатчеризации (на которой легко запороться, так как нет проверки на этапе компиляции). Теперь, при изменении аргументов какого-либо сервиса компилятор начнет ругаться (и мы избежим трудноуловимой ошибки 500). Единственный минус - если поменять аргументы местами, то что-то может полететь уже в рантайме. Это можно исправить, указывая типы ответов в .Match напрямую, но это слишком неудобно и мой автоформаттер все равно их убирает, и мне лень с ним спорить.