### PR TITLE
META: опять чиним пре-коммит

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     hooks:
       - id: prettier
         types_or: [css, javascript, jsx, ts, tsx, html]
+        require_serial: true
   - repo: local
     hooks:
       - id: dotnet-format


### PR DESCRIPTION
Убрал параллельное исполнение обоих хуков, убрал restore у dotnet-format

Кто-то явно не пользуется форматированием, учитывая что 20 файлов были изменены prettier когда я запустил `pre-commit run --all-files`